### PR TITLE
Releasing tasks even if something failed while parsing

### DIFF
--- a/manage.go
+++ b/manage.go
@@ -173,14 +173,13 @@ func (t *TaskService) GetRegisteredTasks() (RegisteredTaskCollection, error) {
 	defer rootTaskCollection.Release()
 	err = oleutil.ForEach(rootTaskCollection, func(v *ole.VARIANT) error {
 		task := v.ToIDispatch()
+		defer task.Release()
 
 		registeredTask, path, err := parseRegisteredTask(task)
 		if err != nil {
 			return fmt.Errorf("error parsing registered task %s: %v", path, err)
 		}
 		registeredTasks = append(registeredTasks, registeredTask)
-
-		task.Release()
 
 		return nil
 	})

--- a/parse.go
+++ b/parse.go
@@ -123,6 +123,12 @@ func parseRegisteredTask(task *ole.IDispatch) (RegisteredTask, string, error) {
 	}
 	context := contextVar.ToString()
 
+	xmlTextVar, err := oleutil.GetProperty(actions, "XmlText")
+	if err != nil {
+		return RegisteredTask{}, "", err
+	}
+	xmlText := xmlTextVar.ToString()
+
 	var taskActions []Action
 	err = oleutil.ForEach(actions, func(v *ole.VARIANT) error {
 		action := v.ToIDispatch()
@@ -202,6 +208,7 @@ func parseRegisteredTask(task *ole.IDispatch) (RegisteredTask, string, error) {
 		Settings:         *taskSettings,
 		RegistrationInfo: *registrationInfo,
 		Triggers:         taskTriggers,
+		XMLText:          xmlText,
 	}
 
 	registeredTask := RegisteredTask{

--- a/parse.go
+++ b/parse.go
@@ -123,12 +123,6 @@ func parseRegisteredTask(task *ole.IDispatch) (RegisteredTask, string, error) {
 	}
 	context := contextVar.ToString()
 
-	xmlTextVar, err := oleutil.GetProperty(actions, "XmlText")
-	if err != nil {
-		return RegisteredTask{}, "", err
-	}
-	xmlText := xmlTextVar.ToString()
-
 	var taskActions []Action
 	err = oleutil.ForEach(actions, func(v *ole.VARIANT) error {
 		action := v.ToIDispatch()
@@ -152,6 +146,13 @@ func parseRegisteredTask(task *ole.IDispatch) (RegisteredTask, string, error) {
 		return RegisteredTask{}, "", err
 	}
 	principal := principalVar.ToIDispatch()
+
+	xmlTextVar, err := oleutil.GetProperty(definition, "XmlText")
+	if err != nil {
+		return RegisteredTask{}, "", err
+	}
+	xmlText := xmlTextVar.ToString()
+
 	defer principal.Release()
 	taskPrincipal := parsePrincipal(principal)
 


### PR DESCRIPTION
It appears as though all other calls to `ToIDispatch()` have a `Release()` call immediately after. I noticed that for tasks, this is not the case, and if there is an error while parsing a task, we will not release the task. Opening a PR to release tasks, even if something goes wrong with parsing.

If this is not correct please let me know! But I believe that even if there is an error, we still need to release, as we have already obtained the memory.