### PR TITLE
Fix MonthlyTrigger field name

### DIFF
--- a/fill.go
+++ b/fill.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package taskmaster
@@ -204,7 +205,7 @@ func fillTaskTriggersObj(triggers []Trigger, triggersObj *ole.IDispatch) error {
 			oleutil.MustPutProperty(monthlyTriggerObj, "DaysOfMonth", uint(t.DaysOfMonth))
 			oleutil.MustPutProperty(monthlyTriggerObj, "MonthsOfYear", uint(t.MonthsOfYear))
 			oleutil.MustPutProperty(monthlyTriggerObj, "RandomDelay", t.RandomDelay.String())
-			oleutil.MustPutProperty(monthlyTriggerObj, "RunOnLastDayOfMonth", t.RunOnLastWeekOfMonth)
+			oleutil.MustPutProperty(monthlyTriggerObj, "RunOnLastDayOfMonth", t.RunOnLastDayOfMonth)
 		case RegistrationTrigger:
 			registrationTriggerObj := triggerObj.MustQueryInterface(ole.NewGUID("{4c8fec3a-c218-4e0c-b23d-629024db91a2}"))
 			defer registrationTriggerObj.Release()

--- a/parse.go
+++ b/parse.go
@@ -538,14 +538,14 @@ func parseTaskTrigger(trigger *ole.IDispatch) (Trigger, error) {
 		if err != nil {
 			return nil, fmt.Errorf("error parsing IMonthlyTrigger object: error parsing RandomDelay field: %v", err)
 		}
-		runOnLastWeekOfMonth := oleutil.MustGetProperty(trigger, "RunOnLastDayOfMonth").Value().(bool)
+		runOnLastDayOfMonth := oleutil.MustGetProperty(trigger, "RunOnLastDayOfMonth").Value().(bool)
 
 		monthlyTrigger := MonthlyTrigger{
-			TaskTrigger:          taskTriggerObj,
-			DaysOfMonth:          daysOfMonth,
-			MonthsOfYear:         monthsOfYear,
-			RandomDelay:          randomDelay,
-			RunOnLastWeekOfMonth: runOnLastWeekOfMonth,
+			TaskTrigger:         taskTriggerObj,
+			DaysOfMonth:         daysOfMonth,
+			MonthsOfYear:        monthsOfYear,
+			RandomDelay:         randomDelay,
+			RunOnLastDayOfMonth: runOnLastDayOfMonth,
 		}
 
 		return monthlyTrigger, nil

--- a/types.go
+++ b/types.go
@@ -838,10 +838,10 @@ type MonthlyDOWTrigger struct {
 // https://docs.microsoft.com/en-us/windows/desktop/api/taskschd/nn-taskschd-imonthlytrigger
 type MonthlyTrigger struct {
 	TaskTrigger
-	DaysOfMonth          DayOfMonth    // the days of the month during which the task runs
-	MonthsOfYear         Month         // the months of the year during which the task runs
-	RandomDelay          period.Period // a delay time that is randomly added to the start time of the trigger
-	RunOnLastWeekOfMonth bool          // indicates that the task runs on the last week of the month
+	DaysOfMonth         DayOfMonth    // the days of the month during which the task runs
+	MonthsOfYear        Month         // the months of the year during which the task runs
+	RandomDelay         period.Period // a delay time that is randomly added to the start time of the trigger
+	RunOnLastDayOfMonth bool          // indicates that the task runs on the last day of the month
 }
 
 // RegistrationTrigger triggers the task when the task is registered.


### PR DESCRIPTION
## Summary
- fix inconsistent struct field name for MonthlyTrigger
- update parsing/filling logic to use RunOnLastDayOfMonth
- run go vet & go build for windows

## Testing
- `GOOS=windows go vet ./...`
- `GOOS=windows go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_68405b674a0483268f247a0b814a83a0